### PR TITLE
Minor typo cheetah.py

### DIFF
--- a/src/om/processing_layer/cheetah.py
+++ b/src/om/processing_layer/cheetah.py
@@ -90,7 +90,7 @@ class CheetahProcessing(OmProcessingProtocol):
                 required=True,
             )
         )
-        processed_directory_path.mkdir(exist_oki=True)
+        processed_directory_path.mkdir(exist_ok=True)
 
         # Geometry
         self._geometry_information = GeometryInformation.from_file(


### PR DESCRIPTION
Changes
- Correct typo in parameter name (`exist_oki` to `exist_ok`)