### PR TITLE
Updated hitrate plot to be a hitrate (was previously just hits, zeros…

### DIFF
--- a/src/om/graphical_interfaces/swaxs_gui.py
+++ b/src/om/graphical_interfaces/swaxs_gui.py
@@ -142,6 +142,15 @@ class SwaxsGui(OmGuiBase):
             symbolSize=3,
             name="ROI2",
         )
+        self._frame_mean_plot: Any = self._roi_widget.plot(
+            tuple(range(-5000, 0)),
+            [0.0] * 5000,
+            pen=None,
+            symbol="o",
+            symbolPen=pyqtgraph.mkPen("w"),
+            symbolSize=3,
+            name="Frame Mean",
+        )
 
         self._radial_stack_view: Any = pyqtgraph.ImageView()
         self._radial_stack_view.view.setAspectLocked(False)
@@ -215,6 +224,7 @@ class SwaxsGui(OmGuiBase):
 
         self._roi1_plot.setData(tuple(range(-5000, 0)), local_data["roi1_int_history"])
         self._roi2_plot.setData(tuple(range(-5000, 0)), local_data["roi2_int_history"])
+        self._frame_mean_plot.setData(tuple(range(-5000, 0)), local_data["image_sum_history"])
 
         QtWidgets.QApplication.processEvents()
 

--- a/src/om/lib/geometry.py
+++ b/src/om/lib/geometry.py
@@ -940,7 +940,7 @@ def _read_crystfel_geometry_from_text(  # noqa: C901
                 elif bad_region_key == "panel":
                     curr_bad_region["panel"] = value
                 else:
-                    raise OmGeometryError"Unrecognized field: {}".format(key))
+                    raise OmGeometryError("Unrecognized field: {}".format(key))
             else:
                 panel_name: str = key_parts[0]
                 panel_key: str = key_parts[1]

--- a/src/om/lib/zmq.py
+++ b/src/om/lib/zmq.py
@@ -208,7 +208,7 @@ class ZmqResponder:
                 raise OmInvalidZmqUrl(
                     "The setup of the data requesting socket failed. The requested"
                     "URL is not valid due to the following reason: "
-                    f"{exc_type.__name__}: {exc_value}.
+                    f"{exc_type.__name__}: {exc_value}."
                 ) from exc
 
         self._zmq_poller: Any = zmq.Poller()

--- a/src/om/processing_layer/swaxs.py
+++ b/src/om/processing_layer/swaxs.py
@@ -207,6 +207,7 @@ class SwaxsProcessing(OmProcessingProtocol):
         roi1_intensity: float
         roi2_intensity: float
         rg: float
+        detector_data_sum: float
         (
             radial_profile,
             errors,
@@ -215,6 +216,7 @@ class SwaxsProcessing(OmProcessingProtocol):
             roi1_intensity,
             roi2_intensity,
             rg,
+            detector_data_sum,
         ) = self._radial_profile_analysis.analyze_radial_profile(
             data=data["detector_data"],
             beam_energy=data["beam_energy"],
@@ -222,7 +224,7 @@ class SwaxsProcessing(OmProcessingProtocol):
             downstream_intensity=data["post_sample_intensity"],
         )
 
-        detector_data_sum: float = data["detector_data"].sum()
+        # detector_data_sum: float = data["detector_data"].sum()
 
         processed_data["radial_profile"] = radial_profile
         processed_data["detector_data_sum"] = detector_data_sum
@@ -305,6 +307,7 @@ class SwaxsProcessing(OmProcessingProtocol):
         downstream_intensity_history: Deque[float]
         roi1_intensity_history: Deque[float]
         roi2_intensity_history: Deque[float]
+        hit_rate_history: Deque[float]
         (
             q_history,
             radials_history,
@@ -350,6 +353,7 @@ class SwaxsProcessing(OmProcessingProtocol):
                 "roi1_int_history": numpy.array(roi1_intensity_history),
                 "roi2_int_history": numpy.array(roi2_intensity_history),
                 "hit_rate_history": numpy.array(hit_rate_history),
+                "image_sum_history": numpy.array(image_sum_history),
                 "rg": numpy.array(rg_history),
                 "timestamp": received_data["timestamp"],
                 "detector_distance": received_data["detector_distance"],
@@ -589,6 +593,7 @@ class SwaxsCheetahProcessing(OmProcessingProtocol):
         roi1_intensity: float
         roi2_intensity: float
         rg: float
+        detector_data_sum: float
         (
             radial_profile,
             q,
@@ -596,6 +601,7 @@ class SwaxsCheetahProcessing(OmProcessingProtocol):
             roi1_intensity,
             roi2_intensity,
             rg,
+            detector_data_sum,
         ) = self._radial_profile_analysis.analyze_radial_profile(
             data=data["detector_data"],
             beam_energy=data["beam_energy"],
@@ -603,7 +609,7 @@ class SwaxsCheetahProcessing(OmProcessingProtocol):
             downstream_intensity=data["post_sample_intensity"],
         )
 
-        detector_data_sum: float = data["detector_data"].sum()
+        # detector_data_sum: float = data["detector_data"].sum()
 
         processed_data["radial_profile"] = radial_profile
         processed_data["detector_data_sum"] = detector_data_sum
@@ -695,6 +701,7 @@ class SwaxsCheetahProcessing(OmProcessingProtocol):
             roi2_intensity_history,
             hit_rate_history,
             rg_history,
+
         ) = self._plots.update_plots(
             radial_profile=received_data["radial_profile"],
             detector_data_sum=received_data["detector_data_sum"],
@@ -704,6 +711,7 @@ class SwaxsCheetahProcessing(OmProcessingProtocol):
             roi2_intensity=received_data["roi2_intensity"],
             sample_detected=received_data["sample_detected"],
             rg=received_data["rg"],
+            frame_sum=received_data["frame_sum"]
         )
 
         # Event counting


### PR DESCRIPTION
… and ones, not calculating an average hitrate). Updated radial_profile.py to utilize num_radials_to_send for the radial stack and running_average_window_size for the hitrate running average window. Hard coded length of plots to be 5000 events, which was previously read from the running average window size instead (but could not actually use a number other than 5000 anyways). Updated swaxs_gui to plot frame mean intensity in ROI panel (which is just the average detector intensity value). Fixed a couple bugs.