### PR TITLE
Fixed psana1 timestamp extraction

### DIFF
--- a/src/om/data_retrieval_layer/data_sources_psana.py
+++ b/src/om/data_retrieval_layer/data_sources_psana.py
@@ -853,9 +853,8 @@ class TimestampPsana(OmDataSourceProtocol):
         )
         timestamp_epoch_format: Any = psana_event_id.time()
         return numpy.float64(
-            str(timestamp_epoch_format[0]) + "." + str(timestamp_epoch_format[1])
+            int((timestamp_epoch_format[0]<<32)|timestamp_epoch_format[1])/10e9
         )
-
 
 class EventIdPsana(OmDataSourceProtocol):
     """


### PR DESCRIPTION
Fixes error in extraction of psana1 timestamp that made it look like the timestamp was jumping back to past values from time to time